### PR TITLE
feat: add tool registry and eval scaffolding

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9,6 +9,8 @@ const index_1 = require("../config/index");
 const index_2 = require("../logging/index");
 const index_js_1 = require("@modelcontextprotocol/sdk/server/index.js");
 const stdio_js_1 = require("@modelcontextprotocol/sdk/server/stdio.js");
+const index_3 = require("../tools/index");
+const index_4 = require("../eval/index");
 const types_js_1 = require("@modelcontextprotocol/sdk/types.js");
 class McpAgentCli {
     mcpServer;
@@ -17,6 +19,8 @@ class McpAgentCli {
     constructor(serverName = 'default-mcp-agent') {
         const config = (0, index_1.createDefaultConfig)(serverName);
         this.localServer = new mcpServer_1.McpServer({ config });
+        // Register built-in tools
+        (0, index_3.registerTools)(this.localServer);
         this.logger = index_2.Logger.getInstance();
         this.mcpServer = new index_js_1.Server({
             name: serverName,
@@ -108,6 +112,18 @@ class McpAgentCli {
             }
             catch (error) {
                 console.error('Error listing resources:', error);
+            }
+        });
+        commander_1.program
+            .command('run-eval')
+            .description('Run evaluation benchmarks')
+            .action(async () => {
+            try {
+                const results = await (0, index_4.runDefaultEvaluation)();
+                console.log('Evaluation Results:', JSON.stringify(results, null, 2));
+            }
+            catch (error) {
+                console.error('Error running evaluation:', error);
             }
         });
         commander_1.program

--- a/dist/eval/index.d.ts
+++ b/dist/eval/index.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Simple benchmarking scaffolding to compare workflows or model outputs.
+ */
+export interface EvaluationCase {
+    id: string;
+    input: unknown;
+    expected?: unknown;
+}
+export interface Workflow {
+    name: string;
+    run: (input: unknown) => Promise<unknown> | unknown;
+}
+export interface CaseResult {
+    caseId: string;
+    output: unknown;
+    expected?: unknown;
+    durationMs: number;
+    success: boolean;
+}
+export interface WorkflowResult {
+    workflow: string;
+    results: CaseResult[];
+}
+/**
+ * Execute a set of workflows against evaluation cases and capture timing/accuracy metrics.
+ */
+export declare function benchmarkWorkflows(workflows: Workflow[], cases: EvaluationCase[]): Promise<WorkflowResult[]>;
+/**
+ * Run a trivial default evaluation used by CLI for demonstration.
+ */
+export declare function runDefaultEvaluation(): Promise<WorkflowResult[]>;

--- a/dist/eval/index.js
+++ b/dist/eval/index.js
@@ -1,0 +1,46 @@
+"use strict";
+/**
+ * Simple benchmarking scaffolding to compare workflows or model outputs.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.benchmarkWorkflows = benchmarkWorkflows;
+exports.runDefaultEvaluation = runDefaultEvaluation;
+/**
+ * Execute a set of workflows against evaluation cases and capture timing/accuracy metrics.
+ */
+async function benchmarkWorkflows(workflows, cases) {
+    const out = [];
+    for (const wf of workflows) {
+        const wfResults = [];
+        for (const c of cases) {
+            const start = Date.now();
+            const output = await wf.run(c.input);
+            const durationMs = Date.now() - start;
+            const success = c.expected === undefined
+                ? true
+                : JSON.stringify(output) === JSON.stringify(c.expected);
+            wfResults.push({
+                caseId: c.id,
+                output,
+                expected: c.expected,
+                durationMs,
+                success,
+            });
+        }
+        out.push({ workflow: wf.name, results: wfResults });
+    }
+    return out;
+}
+/**
+ * Run a trivial default evaluation used by CLI for demonstration.
+ */
+async function runDefaultEvaluation() {
+    const echo = {
+        name: 'echo-workflow',
+        run: async (input) => input,
+    };
+    const cases = [
+        { id: 'case-1', input: { message: 'hello' }, expected: { message: 'hello' } },
+    ];
+    return benchmarkWorkflows([echo], cases);
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -7,4 +7,6 @@ export * from './agents';
 export * from './app';
 export * from './types';
 export * from './utils';
+export * from './tools';
+export * from './eval';
 export declare const VERSION = "0.1.0";

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,5 +30,9 @@ __exportStar(require("./app"), exports);
 __exportStar(require("./types"), exports);
 // Utils
 __exportStar(require("./utils"), exports);
+// Tools
+__exportStar(require("./tools"), exports);
+// Evaluation
+__exportStar(require("./eval"), exports);
 // Version
 exports.VERSION = '0.1.0';

--- a/dist/tools/echo.d.ts
+++ b/dist/tools/echo.d.ts
@@ -1,0 +1,2 @@
+import { ToolHandler } from './types';
+export declare const echoTool: ToolHandler;

--- a/dist/tools/echo.js
+++ b/dist/tools/echo.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.echoTool = void 0;
+exports.echoTool = {
+    name: 'echo',
+    description: 'Echo back a provided message',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            message: { type: 'string' }
+        },
+        required: ['message']
+    },
+    async handler(args) {
+        return { message: String(args.message) };
+    }
+};

--- a/dist/tools/index.d.ts
+++ b/dist/tools/index.d.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '../mcp/mcpServer';
+import { ToolHandler } from './types';
+/**
+ * Default set of tool handlers exposed by the server.
+ */
+export declare const defaultTools: ToolHandler[];
+/**
+ * Register provided tools with an MCP server instance.
+ */
+export declare function registerTools(server: McpServer, tools?: ToolHandler[]): void;
+/**
+ * Convenience method to retrieve tool metadata without handlers.
+ */
+export declare function listTools(tools?: ToolHandler[]): Record<string, unknown>;
+export * from './types';
+export * from './echo';

--- a/dist/tools/index.js
+++ b/dist/tools/index.js
@@ -1,0 +1,53 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultTools = void 0;
+exports.registerTools = registerTools;
+exports.listTools = listTools;
+const echo_1 = require("./echo");
+/**
+ * Default set of tool handlers exposed by the server.
+ */
+exports.defaultTools = [echo_1.echoTool];
+/**
+ * Register provided tools with an MCP server instance.
+ */
+function registerTools(server, tools = exports.defaultTools) {
+    for (const tool of tools) {
+        server.registerTool(tool.name, {
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            outputSchema: tool.outputSchema,
+            handler: tool.handler
+        });
+    }
+}
+/**
+ * Convenience method to retrieve tool metadata without handlers.
+ */
+function listTools(tools = exports.defaultTools) {
+    const result = {};
+    for (const tool of tools) {
+        result[tool.name] = {
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            outputSchema: tool.outputSchema
+        };
+    }
+    return result;
+}
+__exportStar(require("./types"), exports);
+__exportStar(require("./echo"), exports);

--- a/dist/tools/types.d.ts
+++ b/dist/tools/types.d.ts
@@ -1,0 +1,7 @@
+export interface ToolHandler {
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+    handler: (args: Record<string, any>) => Promise<unknown> | unknown;
+}

--- a/dist/tools/types.js
+++ b/dist/tools/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,8 @@ import { createDefaultConfig } from '../config/index';
 import { Logger, LogLevel } from '../logging/index';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { registerTools } from '../tools/index';
+import { runDefaultEvaluation } from '../eval/index';
 import {
   CallToolRequestSchema,
   ErrorCode,
@@ -22,6 +24,8 @@ export class McpAgentCli {
   constructor(serverName: string = 'default-mcp-agent') {
     const config = createDefaultConfig(serverName);
     this.localServer = new McpServer({ config });
+    // Register built-in tools
+    registerTools(this.localServer);
     this.logger = Logger.getInstance();
 
     this.mcpServer = new Server(
@@ -124,6 +128,18 @@ export class McpAgentCli {
           console.log('Available Resources:', JSON.stringify(resources, null, 2));
         } catch (error) {
           console.error('Error listing resources:', error);
+        }
+      });
+
+    program
+      .command('run-eval')
+      .description('Run evaluation benchmarks')
+      .action(async () => {
+        try {
+          const results = await runDefaultEvaluation();
+          console.log('Evaluation Results:', JSON.stringify(results, null, 2));
+        } catch (error) {
+          console.error('Error running evaluation:', error);
         }
       });
 

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Simple benchmarking scaffolding to compare workflows or model outputs.
+ */
+
+export interface EvaluationCase {
+  id: string;
+  input: unknown;
+  expected?: unknown;
+}
+
+export interface Workflow {
+  name: string;
+  run: (input: unknown) => Promise<unknown> | unknown;
+}
+
+export interface CaseResult {
+  caseId: string;
+  output: unknown;
+  expected?: unknown;
+  durationMs: number;
+  success: boolean;
+}
+
+export interface WorkflowResult {
+  workflow: string;
+  results: CaseResult[];
+}
+
+/**
+ * Execute a set of workflows against evaluation cases and capture timing/accuracy metrics.
+ */
+export async function benchmarkWorkflows(
+  workflows: Workflow[],
+  cases: EvaluationCase[]
+): Promise<WorkflowResult[]> {
+  const out: WorkflowResult[] = [];
+  for (const wf of workflows) {
+    const wfResults: CaseResult[] = [];
+    for (const c of cases) {
+      const start = Date.now();
+      const output = await wf.run(c.input);
+      const durationMs = Date.now() - start;
+      const success =
+        c.expected === undefined
+          ? true
+          : JSON.stringify(output) === JSON.stringify(c.expected);
+      wfResults.push({
+        caseId: c.id,
+        output,
+        expected: c.expected,
+        durationMs,
+        success,
+      });
+    }
+    out.push({ workflow: wf.name, results: wfResults });
+  }
+  return out;
+}
+
+/**
+ * Run a trivial default evaluation used by CLI for demonstration.
+ */
+export async function runDefaultEvaluation(): Promise<WorkflowResult[]> {
+  const echo: Workflow = {
+    name: 'echo-workflow',
+    run: async (input: unknown) => input,
+  };
+
+  const cases: EvaluationCase[] = [
+    { id: 'case-1', input: { message: 'hello' }, expected: { message: 'hello' } },
+  ];
+
+  return benchmarkWorkflows([echo], cases);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,5 +20,11 @@ export * from './types';
 // Utils
 export * from './utils';
 
+// Tools
+export * from './tools';
+
+// Evaluation
+export * from './eval';
+
 // Version
 export const VERSION = '0.1.0';

--- a/src/tools/echo.ts
+++ b/src/tools/echo.ts
@@ -1,0 +1,16 @@
+import { ToolHandler } from './types';
+
+export const echoTool: ToolHandler = {
+  name: 'echo',
+  description: 'Echo back a provided message',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message: { type: 'string' }
+    },
+    required: ['message']
+  },
+  async handler(args: Record<string, any>): Promise<{ message: string }> {
+    return { message: String(args.message) };
+  }
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,40 @@
+import { McpServer } from '../mcp/mcpServer';
+import { ToolHandler } from './types';
+import { echoTool } from './echo';
+
+/**
+ * Default set of tool handlers exposed by the server.
+ */
+export const defaultTools: ToolHandler[] = [echoTool];
+
+/**
+ * Register provided tools with an MCP server instance.
+ */
+export function registerTools(server: McpServer, tools: ToolHandler[] = defaultTools): void {
+  for (const tool of tools) {
+    server.registerTool(tool.name, {
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      outputSchema: tool.outputSchema,
+      handler: tool.handler
+    });
+  }
+}
+
+/**
+ * Convenience method to retrieve tool metadata without handlers.
+ */
+export function listTools(tools: ToolHandler[] = defaultTools): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const tool of tools) {
+    result[tool.name] = {
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      outputSchema: tool.outputSchema
+    };
+  }
+  return result;
+}
+
+export * from './types';
+export * from './echo';

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,0 +1,7 @@
+export interface ToolHandler {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  handler: (args: Record<string, any>) => Promise<unknown> | unknown;
+}


### PR DESCRIPTION
## Summary
- add generic tool registry with sample echo tool
- scaffold evaluation module for benchmarking workflows
- extend CLI with run-eval command and default tool registration

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
- `node dist/cli/index.js list-tools`
- `node dist/cli/index.js run-eval`


------
https://chatgpt.com/codex/tasks/task_e_6898268750908325ba17ec6a66539c33